### PR TITLE
scripts: Add shebang to script file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 LIB_FILES="src/Texture.cpp src/ShaderProgram.cpp src/Game.cpp"
 LIB_OPTIONS="-lSD2 -lGLEW -lGL -ldl -lfPIC -shared -o game.so -g"
 GAME_OPTIONS="-lSD2 -lGLEW -lGL -ldl -o game -g"


### PR DESCRIPTION
Add shebang to script file, required in rare cases to process file as actual shell file. 